### PR TITLE
@craigspaeth No longer binding to resize events for iOS devices

### DIFF
--- a/jquery.fillwidth.js
+++ b/jquery.fillwidth.js
@@ -275,19 +275,21 @@
         methods.initStyling.call(this, el);
         initFillWidth = __bind(function() {
           methods.fillWidth.call(this, el);
-          $(window).bind('resize.fillwidth', debounce((__bind(function() {
-            var fn, _i, _len;
-            callQueue.push((__bind(function() {
-              return methods.fillWidth.call(this, el);
-            }, this)));
-            if (callQueue.length === totalPlugins) {
-              for (_i = 0, _len = callQueue.length; _i < _len; _i++) {
-                fn = callQueue[_i];
-                fn();
+          if (!(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPod/i))) {
+            $(window).bind('resize.fillwidth', debounce((__bind(function() {
+              var fn, _i, _len;
+              callQueue.push((__bind(function() {
+                return methods.fillWidth.call(this, el);
+              }, this)));
+              if (callQueue.length === totalPlugins) {
+                for (_i = 0, _len = callQueue.length; _i < _len; _i++) {
+                  fn = callQueue[_i];
+                  fn();
+                }
+                return callQueue = [];
               }
-              return callQueue = [];
-            }
-          }, this)), 300));
+            }, this)), 300));
+          }
           return totalPlugins++;
         }, this);
         $imgs = $(el).find('img');


### PR DESCRIPTION
The real issue is that on iOS devices changing document height triggers a 'resize' event. Since we cannot fix that issue, we work around it by not binding to resize events on ios devices. 

The scenario: Fillwidth resizes images -> _document height changed_ -> _resize event fired_ -> Fillwidth resizes images -> repeat infinitely...

Sorry for all the whitespace in the diff (.____.)

The actual code is: https://github.com/zamiang/jquery.fillwidth/pull/new/i_device_fix#L0R184
