### PR TITLE
@craigspaeth Remove Firefox 'ghost scrollbar' fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+*~
+# Sublime
+*.sublime-project
+*.sublime-workspace
+
+# Emacs
+*#
+.#*
+
+node_modules/

--- a/example/src/jquery.fillwidth.js
+++ b/example/src/jquery.fillwidth.js
@@ -275,19 +275,21 @@
         methods.initStyling.call(this, el);
         initFillWidth = __bind(function() {
           methods.fillWidth.call(this, el);
-          $(window).bind('resize.fillwidth', debounce((__bind(function() {
-            var fn, _i, _len;
-            callQueue.push((__bind(function() {
-              return methods.fillWidth.call(this, el);
-            }, this)));
-            if (callQueue.length === totalPlugins) {
-              for (_i = 0, _len = callQueue.length; _i < _len; _i++) {
-                fn = callQueue[_i];
-                fn();
+          if (!(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPod/i))) {
+            $(window).bind('resize.fillwidth', debounce((__bind(function() {
+              var fn, _i, _len;
+              callQueue.push((__bind(function() {
+                return methods.fillWidth.call(this, el);
+              }, this)));
+              if (callQueue.length === totalPlugins) {
+                for (_i = 0, _len = callQueue.length; _i < _len; _i++) {
+                  fn = callQueue[_i];
+                  fn();
+                }
+                return callQueue = [];
               }
-              return callQueue = [];
-            }
-          }, this)), 300));
+            }, this)), 300));
+          }
           return totalPlugins++;
         }, this);
         $imgs = $(el).find('img');
@@ -386,7 +388,6 @@
         row.lockHeight();
         row.updateDOM();
       }
-      methods.firefoxScrollbarBug.call(this, el);
       $(el).trigger('fillwidth.afterFillWidth');
       if (this.settings.afterFillWidth != null) {
         return this.settings.afterFillWidth();
@@ -440,36 +441,6 @@
         }
       }, this));
       return rows;
-    },
-    firefoxScrollbarBug: function(el) {
-      if (!$.browser.mozilla) {
-        return;
-      }
-      return setTimeout((function() {
-        var $lastLi, diff, i, index, randomRow, row, rows, _i, _len, _ref, _results;
-        rows = $(el).data('fillwidth.rows');
-        if (rows == null) {
-          return;
-        }
-        _ref = rows.slice(0, (rows.length - 2 + 1) || 9e9);
-        _results = [];
-        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-          row = _ref[_i];
-          $lastLi = row.lis[row.lis.length - 1].$el;
-          diff = $(el).width() - ($lastLi.outerWidth(true) + $lastLi.position().left);
-          _results.push((function() {
-            if (diff === 24) {
-              for (i = 1; i <= 15; i++) {
-                index = Math.round(Math.random() * (row.lis.length - 1));
-                randomRow = row.lis[index];
-                randomRow.incWidth();
-              }
-              return row.updateDOM();
-            }
-          })());
-        }
-        return _results;
-      }), 1);
     }
   };
   $.fn.fillwidth = function(method) {

--- a/jquery.fillwidth.coffee
+++ b/jquery.fillwidth.coffee
@@ -262,8 +262,6 @@ methods =
       row.lockHeight()
       row.updateDOM()
 
-    methods.firefoxScrollbarBug.call @, el
-
     $(el).trigger 'fillwidth.afterFillWidth'
     @settings.afterFillWidth() if @settings.afterFillWidth?
 
@@ -297,23 +295,6 @@ methods =
         rows.push new Row(@frameWidth, @settings)
         i++
     rows
-
-  # Firefox work-around for ghost scrollbar bug
-  firefoxScrollbarBug: (el) ->
-    return unless $.browser.mozilla
-    setTimeout (->
-      rows = $(el).data 'fillwidth.rows'
-      return unless rows?
-      for row in rows[0..rows.length - 2]
-        $lastLi = row.lis[row.lis.length - 1].$el
-        diff = $(el).width() - ($lastLi.outerWidth(true) + $lastLi.position().left)
-        if diff is 24
-          for i in [1..15]
-            index = Math.round Math.random() * (row.lis.length - 1)
-            randomRow = row.lis[index]
-            randomRow.incWidth()
-          row.updateDOM()
-    ), 1
 
 # Either call a method if passed a string, or call init if passed an object
 $.fn.fillwidth = (method) ->

--- a/jquery.fillwidth.js
+++ b/jquery.fillwidth.js
@@ -1,14 +1,10 @@
 (function() {
   var $, Li, Row, callQueue, debounce, methods, totalPlugins;
-
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
   $ = jQuery;
-
   totalPlugins = 0;
-
   callQueue = [];
-
   Li = (function() {
-
     function Li(el, settings) {
       var $img;
       this.originalWidth = this.width = $(el).outerWidth();
@@ -19,35 +15,28 @@
       this.$el = $(el);
       this.settings = settings;
     }
-
     Li.prototype.setHeight = function(h) {
       this.width = h * (this.width / this.height);
       if (!this.settings.lockedHeight) {
         return this.height = h;
       }
     };
-
     Li.prototype.setWidth = function(w) {
       this.height = w * (this.height / this.width);
       return this.width = w;
     };
-
     Li.prototype.decWidth = function() {
       return this.setWidth(this.width - 1);
     };
-
     Li.prototype.decHeight = function() {
       return this.setHeight(this.height - 1);
     };
-
     Li.prototype.incWidth = function() {
       return this.setWidth(this.width + 1);
     };
-
     Li.prototype.incHeight = function() {
       return this.setHeight(this.height + 1);
     };
-
     Li.prototype.updateDOM = function() {
       this.$el.width(this.width);
       this.$el.height(this.height);
@@ -55,7 +44,6 @@
         'margin-right': this.margin
       });
     };
-
     Li.prototype.reset = function() {
       this.width = this.originalWidth;
       this.height = this.originalHeight;
@@ -66,19 +54,14 @@
         height: this.height
       });
     };
-
     return Li;
-
   })();
-
   Row = (function() {
-
     function Row(frameWidth, settings) {
       this.frameWidth = frameWidth;
       this.settings = settings;
       this.lis = [];
     }
-
     Row.prototype.width = function() {
       var li, width, _i, _len, _ref;
       width = 0;
@@ -89,7 +72,6 @@
       }
       return width;
     };
-
     Row.prototype.updateDOM = function() {
       var li, _i, _len, _ref, _results;
       _ref = this.lis;
@@ -100,7 +82,6 @@
       }
       return _results;
     };
-
     Row.prototype.reset = function() {
       var li, _i, _len, _ref, _results;
       _ref = this.lis;
@@ -111,7 +92,6 @@
       }
       return _results;
     };
-
     Row.prototype.landscapeGroups = function() {
       var i, landscapeGroups, landscapes, li, ratio, _ref;
       landscapeGroups = [];
@@ -119,11 +99,11 @@
       for (i in _ref) {
         ratio = _ref[i];
         landscapes = (function() {
-          var _i, _len, _ref1, _results;
-          _ref1 = this.lis;
+          var _i, _len, _ref2, _results;
+          _ref2 = this.lis;
           _results = [];
-          for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
-            li = _ref1[_i];
+          for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
+            li = _ref2[_i];
             if (li.imgRatio >= ratio) {
               _results.push(li);
             }
@@ -134,38 +114,35 @@
       }
       return landscapeGroups;
     };
-
     Row.prototype.resizeLandscapes = function() {
-      var i, landscapes, li, _i, _j, _k, _len, _len1, _ref, _ref1;
+      var i, landscapes, li, _i, _j, _len, _len2, _ref, _ref2;
       _ref = this.landscapeGroups(this.settings.landscapeRatios);
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         landscapes = _ref[_i];
-        if (!(landscapes.length !== 0)) {
-          continue;
-        }
-        for (i = _j = 0, _ref1 = this.settings.resizeLandscapesBy; 0 <= _ref1 ? _j <= _ref1 : _j >= _ref1; i = 0 <= _ref1 ? ++_j : --_j) {
-          for (_k = 0, _len1 = landscapes.length; _k < _len1; _k++) {
-            li = landscapes[_k];
-            li.decHeight();
+        if (landscapes.length !== 0) {
+          for (i = 0, _ref2 = this.settings.resizeLandscapesBy; 0 <= _ref2 ? i <= _ref2 : i >= _ref2; 0 <= _ref2 ? i++ : i--) {
+            for (_j = 0, _len2 = landscapes.length; _j < _len2; _j++) {
+              li = landscapes[_j];
+              li.decHeight();
+            }
+            if (this.width() <= this.frameWidth) {
+              break;
+            }
           }
           if (this.width() <= this.frameWidth) {
             break;
           }
         }
-        if (this.width() <= this.frameWidth) {
-          break;
-        }
       }
       return this;
     };
-
     Row.prototype.adjustMargins = function() {
-      var i, li, _i, _j, _len, _ref, _ref1, _results;
+      var i, li, _i, _len, _ref, _ref2, _results;
       _results = [];
-      for (i = _i = 0, _ref = this.settings.adjustMarginsBy; 0 <= _ref ? _i <= _ref : _i >= _ref; i = 0 <= _ref ? ++_i : --_i) {
-        _ref1 = this.lis.slice(0, (this.lis.length - 2) + 1 || 9e9);
-        for (_j = 0, _len = _ref1.length; _j < _len; _j++) {
-          li = _ref1[_j];
+      for (i = 0, _ref = this.settings.adjustMarginsBy; 0 <= _ref ? i <= _ref : i >= _ref; 0 <= _ref ? i++ : i--) {
+        _ref2 = this.lis.slice(0, (this.lis.length - 2 + 1) || 9e9);
+        for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
+          li = _ref2[_i];
           li.margin--;
           if (this.width() <= this.frameWidth) {
             break;
@@ -173,13 +150,10 @@
         }
         if (this.width() <= this.frameWidth) {
           break;
-        } else {
-          _results.push(void 0);
         }
       }
       return _results;
     };
-
     Row.prototype.resizeHeight = function() {
       var i, li, _results;
       i = 0;
@@ -187,19 +161,18 @@
       while (this.width() > this.frameWidth && i < this.settings.resizeRowBy) {
         i++;
         _results.push((function() {
-          var _i, _len, _ref, _results1;
+          var _i, _len, _ref, _results2;
           _ref = this.lis;
-          _results1 = [];
+          _results2 = [];
           for (_i = 0, _len = _ref.length; _i < _len; _i++) {
             li = _ref[_i];
-            _results1.push(li.decHeight());
+            _results2.push(li.decHeight());
           }
-          return _results1;
+          return _results2;
         }).call(this));
       }
       return _results;
     };
-
     Row.prototype.roundOff = function() {
       var li, _i, _len, _ref, _results;
       _ref = this.lis;
@@ -210,32 +183,24 @@
       }
       return _results;
     };
-
     Row.prototype.fillLeftoverPixels = function() {
-      var diff, randIndex, _results,
-        _this = this;
+      var diff, randIndex, _results;
       this.roundOff();
-      diff = function() {
-        return _this.frameWidth - _this.width();
-      };
+      diff = __bind(function() {
+        return this.frameWidth - this.width();
+      }, this);
       _results = [];
       while (diff() !== 0) {
         randIndex = Math.round(Math.random() * (this.lis.length - 1));
-        if (diff() < 0) {
-          _results.push(this.lis[randIndex].decWidth());
-        } else {
-          _results.push(this.lis[randIndex].incWidth());
-        }
+        _results.push(diff() < 0 ? this.lis[randIndex].decWidth() : this.lis[randIndex].incWidth());
       }
       return _results;
     };
-
     Row.prototype.removeMargin = function() {
       var lastLi;
       lastLi = this.lis[this.lis.length - 1];
       return lastLi.margin = 0;
     };
-
     Row.prototype.lockHeight = function() {
       var li, tallestHeight, tallestLi, _i, _len, _ref, _results;
       tallestLi = (this.lis.sort(function(a, b) {
@@ -250,7 +215,6 @@
       }
       return _results;
     };
-
     Row.prototype.hide = function() {
       var li, _i, _len, _ref, _results;
       _ref = this.lis;
@@ -261,7 +225,6 @@
       }
       return _results;
     };
-
     Row.prototype.show = function() {
       var li, _i, _len, _ref, _results;
       _ref = this.lis;
@@ -272,38 +235,32 @@
       }
       return _results;
     };
-
     return Row;
-
   })();
-
   debounce = function(func, wait) {
     var timeout;
     timeout = 0;
     return function() {
-      var args, throttler,
-        _this = this;
+      var args, throttler;
       args = arguments;
-      throttler = function() {
+      throttler = __bind(function() {
         timeout = null;
         return func(args);
-      };
+      }, this);
       clearTimeout(timeout);
       return timeout = setTimeout(throttler, wait);
     };
   };
-
   methods = {
     init: function(settings) {
-      var i, _defaults,
-        _this = this;
+      var i, _defaults;
       _defaults = {
         resizeLandscapesBy: 200,
         resizeRowBy: 15,
         landscapeRatios: ((function() {
-          var _i, _results;
+          var _results;
           _results = [];
-          for (i = _i = 10; _i <= 50; i = _i += 3) {
+          for (i = 10; i <= 50; i += 3) {
             _results.push(i / 10);
           }
           return _results;
@@ -313,17 +270,17 @@
         afterFillWidth: null
       };
       this.settings = $.extend(_defaults, settings);
-      return this.each(function(i, el) {
+      return this.each(__bind(function(i, el) {
         var $imgs, imagesToLoad, initFillWidth;
-        methods.initStyling.call(_this, el);
-        initFillWidth = function() {
-          methods.fillWidth.call(_this, el);
+        methods.initStyling.call(this, el);
+        initFillWidth = __bind(function() {
+          methods.fillWidth.call(this, el);
           if (!(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPod/i))) {
-            $(window).bind('resize.fillwidth', debounce((function() {
+            $(window).bind('resize.fillwidth', debounce((__bind(function() {
               var fn, _i, _len;
-              callQueue.push((function() {
-                return methods.fillWidth.call(_this, el);
-              }));
+              callQueue.push((__bind(function() {
+                return methods.fillWidth.call(this, el);
+              }, this)));
               if (callQueue.length === totalPlugins) {
                 for (_i = 0, _len = callQueue.length; _i < _len; _i++) {
                   fn = callQueue[_i];
@@ -331,12 +288,12 @@
                 }
                 return callQueue = [];
               }
-            }), 300));
+            }, this)), 300));
           }
           return totalPlugins++;
-        };
+        }, this);
         $imgs = $(el).find('img');
-        if (_this.settings.liWidths != null) {
+        if (this.settings.liWidths != null) {
           initFillWidth();
           return $imgs.load(function() {
             return $(this).height('auto');
@@ -350,10 +307,9 @@
             }
           });
         }
-      });
+      }, this));
     },
     initStyling: function(el) {
-      var _this = this;
       $(el).css({
         'list-style': 'none',
         padding: 0,
@@ -372,9 +328,9 @@
         'max-height': '100%'
       });
       if (this.settings && (this.settings.liWidths != null)) {
-        return $(el).children('li').each(function(i, el) {
-          return $(el).width(_this.settings.liWidths[i]);
-        });
+        return $(el).children('li').each(__bind(function(i, el) {
+          return $(el).width(this.settings.liWidths[i]);
+        }, this));
       }
     },
     destroy: function() {
@@ -390,7 +346,7 @@
       });
     },
     fillWidth: function(el) {
-      var row, rows, _i, _j, _len, _len1, _ref;
+      var row, rows, _i, _j, _len, _len2, _ref;
       $(el).trigger('fillwidth.beforeFillWidth');
       if (this.settings.beforeFillWidth != null) {
         this.settings.beforeFillWidth();
@@ -415,7 +371,7 @@
       if (this.settings.afterNewRows != null) {
         this.settings.afterNewRows();
       }
-      for (_j = 0, _len1 = rows.length; _j < _len1; _j++) {
+      for (_j = 0, _len2 = rows.length; _j < _len2; _j++) {
         row = rows[_j];
         if (!(row.lis.length > 1)) {
           continue;
@@ -455,10 +411,10 @@
       for (_i = 0, _len = rows.length; _i < _len; _i++) {
         row = rows[_i];
         arr.push((function() {
-          var _j, _len1, _ref, _results;
+          var _j, _len2, _ref, _results;
           _ref = row.lis;
           _results = [];
-          for (_j = 0, _len1 = _ref.length; _j < _len1; _j++) {
+          for (_j = 0, _len2 = _ref.length; _j < _len2; _j++) {
             li = _ref[_j];
             _results.push(li.$el);
           }
@@ -471,24 +427,22 @@
       return arr;
     },
     breakUpIntoRows: function(el) {
-      var i, rows,
-        _this = this;
+      var i, rows;
       i = 0;
       rows = [new Row(this.frameWidth, this.settings)];
-      $(el).children('li').each(function(j, li) {
+      $(el).children('li').each(__bind(function(j, li) {
         if ($(li).is(':hidden')) {
           return;
         }
-        rows[i].lis.push(new Li(li, _this.settings));
+        rows[i].lis.push(new Li(li, this.settings));
         if (rows[i].width() >= $(el).width() && j !== $(el).children('li').length - 1) {
-          rows.push(new Row(_this.frameWidth, _this.settings));
+          rows.push(new Row(this.frameWidth, this.settings));
           return i++;
         }
-      });
+      }, this));
       return rows;
     }
   };
-
   $.fn.fillwidth = function(method) {
     if (methods[method] != null) {
       return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
@@ -498,5 +452,4 @@
       return $.error("Method " + method + " does not exist on jQuery.fillwidth");
     }
   };
-
 }).call(this);

--- a/jquery.fillwidth.js
+++ b/jquery.fillwidth.js
@@ -1,10 +1,14 @@
 (function() {
   var $, Li, Row, callQueue, debounce, methods, totalPlugins;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
   $ = jQuery;
+
   totalPlugins = 0;
+
   callQueue = [];
+
   Li = (function() {
+
     function Li(el, settings) {
       var $img;
       this.originalWidth = this.width = $(el).outerWidth();
@@ -15,28 +19,35 @@
       this.$el = $(el);
       this.settings = settings;
     }
+
     Li.prototype.setHeight = function(h) {
       this.width = h * (this.width / this.height);
       if (!this.settings.lockedHeight) {
         return this.height = h;
       }
     };
+
     Li.prototype.setWidth = function(w) {
       this.height = w * (this.height / this.width);
       return this.width = w;
     };
+
     Li.prototype.decWidth = function() {
       return this.setWidth(this.width - 1);
     };
+
     Li.prototype.decHeight = function() {
       return this.setHeight(this.height - 1);
     };
+
     Li.prototype.incWidth = function() {
       return this.setWidth(this.width + 1);
     };
+
     Li.prototype.incHeight = function() {
       return this.setHeight(this.height + 1);
     };
+
     Li.prototype.updateDOM = function() {
       this.$el.width(this.width);
       this.$el.height(this.height);
@@ -44,6 +55,7 @@
         'margin-right': this.margin
       });
     };
+
     Li.prototype.reset = function() {
       this.width = this.originalWidth;
       this.height = this.originalHeight;
@@ -54,14 +66,19 @@
         height: this.height
       });
     };
+
     return Li;
+
   })();
+
   Row = (function() {
+
     function Row(frameWidth, settings) {
       this.frameWidth = frameWidth;
       this.settings = settings;
       this.lis = [];
     }
+
     Row.prototype.width = function() {
       var li, width, _i, _len, _ref;
       width = 0;
@@ -72,6 +89,7 @@
       }
       return width;
     };
+
     Row.prototype.updateDOM = function() {
       var li, _i, _len, _ref, _results;
       _ref = this.lis;
@@ -82,6 +100,7 @@
       }
       return _results;
     };
+
     Row.prototype.reset = function() {
       var li, _i, _len, _ref, _results;
       _ref = this.lis;
@@ -92,6 +111,7 @@
       }
       return _results;
     };
+
     Row.prototype.landscapeGroups = function() {
       var i, landscapeGroups, landscapes, li, ratio, _ref;
       landscapeGroups = [];
@@ -99,11 +119,11 @@
       for (i in _ref) {
         ratio = _ref[i];
         landscapes = (function() {
-          var _i, _len, _ref2, _results;
-          _ref2 = this.lis;
+          var _i, _len, _ref1, _results;
+          _ref1 = this.lis;
           _results = [];
-          for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-            li = _ref2[_i];
+          for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
+            li = _ref1[_i];
             if (li.imgRatio >= ratio) {
               _results.push(li);
             }
@@ -114,36 +134,20 @@
       }
       return landscapeGroups;
     };
+
     Row.prototype.resizeLandscapes = function() {
-      var i, landscapes, li, _i, _j, _len, _len2, _ref, _ref2;
+      var i, landscapes, li, _i, _j, _k, _len, _len1, _ref, _ref1;
       _ref = this.landscapeGroups(this.settings.landscapeRatios);
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         landscapes = _ref[_i];
-        if (landscapes.length !== 0) {
-          for (i = 0, _ref2 = this.settings.resizeLandscapesBy; 0 <= _ref2 ? i <= _ref2 : i >= _ref2; 0 <= _ref2 ? i++ : i--) {
-            for (_j = 0, _len2 = landscapes.length; _j < _len2; _j++) {
-              li = landscapes[_j];
-              li.decHeight();
-            }
-            if (this.width() <= this.frameWidth) {
-              break;
-            }
-          }
-          if (this.width() <= this.frameWidth) {
-            break;
-          }
+        if (!(landscapes.length !== 0)) {
+          continue;
         }
-      }
-      return this;
-    };
-    Row.prototype.adjustMargins = function() {
-      var i, li, _i, _len, _ref, _ref2, _results;
-      _results = [];
-      for (i = 0, _ref = this.settings.adjustMarginsBy; 0 <= _ref ? i <= _ref : i >= _ref; 0 <= _ref ? i++ : i--) {
-        _ref2 = this.lis.slice(0, (this.lis.length - 2 + 1) || 9e9);
-        for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-          li = _ref2[_i];
-          li.margin--;
+        for (i = _j = 0, _ref1 = this.settings.resizeLandscapesBy; 0 <= _ref1 ? _j <= _ref1 : _j >= _ref1; i = 0 <= _ref1 ? ++_j : --_j) {
+          for (_k = 0, _len1 = landscapes.length; _k < _len1; _k++) {
+            li = landscapes[_k];
+            li.decHeight();
+          }
           if (this.width() <= this.frameWidth) {
             break;
           }
@@ -152,8 +156,30 @@
           break;
         }
       }
+      return this;
+    };
+
+    Row.prototype.adjustMargins = function() {
+      var i, li, _i, _j, _len, _ref, _ref1, _results;
+      _results = [];
+      for (i = _i = 0, _ref = this.settings.adjustMarginsBy; 0 <= _ref ? _i <= _ref : _i >= _ref; i = 0 <= _ref ? ++_i : --_i) {
+        _ref1 = this.lis.slice(0, (this.lis.length - 2) + 1 || 9e9);
+        for (_j = 0, _len = _ref1.length; _j < _len; _j++) {
+          li = _ref1[_j];
+          li.margin--;
+          if (this.width() <= this.frameWidth) {
+            break;
+          }
+        }
+        if (this.width() <= this.frameWidth) {
+          break;
+        } else {
+          _results.push(void 0);
+        }
+      }
       return _results;
     };
+
     Row.prototype.resizeHeight = function() {
       var i, li, _results;
       i = 0;
@@ -161,18 +187,19 @@
       while (this.width() > this.frameWidth && i < this.settings.resizeRowBy) {
         i++;
         _results.push((function() {
-          var _i, _len, _ref, _results2;
+          var _i, _len, _ref, _results1;
           _ref = this.lis;
-          _results2 = [];
+          _results1 = [];
           for (_i = 0, _len = _ref.length; _i < _len; _i++) {
             li = _ref[_i];
-            _results2.push(li.decHeight());
+            _results1.push(li.decHeight());
           }
-          return _results2;
+          return _results1;
         }).call(this));
       }
       return _results;
     };
+
     Row.prototype.roundOff = function() {
       var li, _i, _len, _ref, _results;
       _ref = this.lis;
@@ -183,24 +210,32 @@
       }
       return _results;
     };
+
     Row.prototype.fillLeftoverPixels = function() {
-      var diff, randIndex, _results;
+      var diff, randIndex, _results,
+        _this = this;
       this.roundOff();
-      diff = __bind(function() {
-        return this.frameWidth - this.width();
-      }, this);
+      diff = function() {
+        return _this.frameWidth - _this.width();
+      };
       _results = [];
       while (diff() !== 0) {
         randIndex = Math.round(Math.random() * (this.lis.length - 1));
-        _results.push(diff() < 0 ? this.lis[randIndex].decWidth() : this.lis[randIndex].incWidth());
+        if (diff() < 0) {
+          _results.push(this.lis[randIndex].decWidth());
+        } else {
+          _results.push(this.lis[randIndex].incWidth());
+        }
       }
       return _results;
     };
+
     Row.prototype.removeMargin = function() {
       var lastLi;
       lastLi = this.lis[this.lis.length - 1];
       return lastLi.margin = 0;
     };
+
     Row.prototype.lockHeight = function() {
       var li, tallestHeight, tallestLi, _i, _len, _ref, _results;
       tallestLi = (this.lis.sort(function(a, b) {
@@ -215,6 +250,7 @@
       }
       return _results;
     };
+
     Row.prototype.hide = function() {
       var li, _i, _len, _ref, _results;
       _ref = this.lis;
@@ -225,6 +261,7 @@
       }
       return _results;
     };
+
     Row.prototype.show = function() {
       var li, _i, _len, _ref, _results;
       _ref = this.lis;
@@ -235,32 +272,38 @@
       }
       return _results;
     };
+
     return Row;
+
   })();
+
   debounce = function(func, wait) {
     var timeout;
     timeout = 0;
     return function() {
-      var args, throttler;
+      var args, throttler,
+        _this = this;
       args = arguments;
-      throttler = __bind(function() {
+      throttler = function() {
         timeout = null;
         return func(args);
-      }, this);
+      };
       clearTimeout(timeout);
       return timeout = setTimeout(throttler, wait);
     };
   };
+
   methods = {
     init: function(settings) {
-      var i, _defaults;
+      var i, _defaults,
+        _this = this;
       _defaults = {
         resizeLandscapesBy: 200,
         resizeRowBy: 15,
         landscapeRatios: ((function() {
-          var _results;
+          var _i, _results;
           _results = [];
-          for (i = 10; i <= 50; i += 3) {
+          for (i = _i = 10; _i <= 50; i = _i += 3) {
             _results.push(i / 10);
           }
           return _results;
@@ -270,17 +313,17 @@
         afterFillWidth: null
       };
       this.settings = $.extend(_defaults, settings);
-      return this.each(__bind(function(i, el) {
+      return this.each(function(i, el) {
         var $imgs, imagesToLoad, initFillWidth;
-        methods.initStyling.call(this, el);
-        initFillWidth = __bind(function() {
-          methods.fillWidth.call(this, el);
+        methods.initStyling.call(_this, el);
+        initFillWidth = function() {
+          methods.fillWidth.call(_this, el);
           if (!(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPod/i))) {
-            $(window).bind('resize.fillwidth', debounce((__bind(function() {
+            $(window).bind('resize.fillwidth', debounce((function() {
               var fn, _i, _len;
-              callQueue.push((__bind(function() {
-                return methods.fillWidth.call(this, el);
-              }, this)));
+              callQueue.push((function() {
+                return methods.fillWidth.call(_this, el);
+              }));
               if (callQueue.length === totalPlugins) {
                 for (_i = 0, _len = callQueue.length; _i < _len; _i++) {
                   fn = callQueue[_i];
@@ -288,12 +331,12 @@
                 }
                 return callQueue = [];
               }
-            }, this)), 300));
+            }), 300));
           }
           return totalPlugins++;
-        }, this);
+        };
         $imgs = $(el).find('img');
-        if (this.settings.liWidths != null) {
+        if (_this.settings.liWidths != null) {
           initFillWidth();
           return $imgs.load(function() {
             return $(this).height('auto');
@@ -307,9 +350,10 @@
             }
           });
         }
-      }, this));
+      });
     },
     initStyling: function(el) {
+      var _this = this;
       $(el).css({
         'list-style': 'none',
         padding: 0,
@@ -328,9 +372,9 @@
         'max-height': '100%'
       });
       if (this.settings && (this.settings.liWidths != null)) {
-        return $(el).children('li').each(__bind(function(i, el) {
-          return $(el).width(this.settings.liWidths[i]);
-        }, this));
+        return $(el).children('li').each(function(i, el) {
+          return $(el).width(_this.settings.liWidths[i]);
+        });
       }
     },
     destroy: function() {
@@ -346,7 +390,7 @@
       });
     },
     fillWidth: function(el) {
-      var row, rows, _i, _j, _len, _len2, _ref;
+      var row, rows, _i, _j, _len, _len1, _ref;
       $(el).trigger('fillwidth.beforeFillWidth');
       if (this.settings.beforeFillWidth != null) {
         this.settings.beforeFillWidth();
@@ -371,7 +415,7 @@
       if (this.settings.afterNewRows != null) {
         this.settings.afterNewRows();
       }
-      for (_j = 0, _len2 = rows.length; _j < _len2; _j++) {
+      for (_j = 0, _len1 = rows.length; _j < _len1; _j++) {
         row = rows[_j];
         if (!(row.lis.length > 1)) {
           continue;
@@ -388,7 +432,6 @@
         row.lockHeight();
         row.updateDOM();
       }
-      methods.firefoxScrollbarBug.call(this, el);
       $(el).trigger('fillwidth.afterFillWidth');
       if (this.settings.afterFillWidth != null) {
         return this.settings.afterFillWidth();
@@ -412,10 +455,10 @@
       for (_i = 0, _len = rows.length; _i < _len; _i++) {
         row = rows[_i];
         arr.push((function() {
-          var _j, _len2, _ref, _results;
+          var _j, _len1, _ref, _results;
           _ref = row.lis;
           _results = [];
-          for (_j = 0, _len2 = _ref.length; _j < _len2; _j++) {
+          for (_j = 0, _len1 = _ref.length; _j < _len1; _j++) {
             li = _ref[_j];
             _results.push(li.$el);
           }
@@ -428,52 +471,24 @@
       return arr;
     },
     breakUpIntoRows: function(el) {
-      var i, rows;
+      var i, rows,
+        _this = this;
       i = 0;
       rows = [new Row(this.frameWidth, this.settings)];
-      $(el).children('li').each(__bind(function(j, li) {
+      $(el).children('li').each(function(j, li) {
         if ($(li).is(':hidden')) {
           return;
         }
-        rows[i].lis.push(new Li(li, this.settings));
+        rows[i].lis.push(new Li(li, _this.settings));
         if (rows[i].width() >= $(el).width() && j !== $(el).children('li').length - 1) {
-          rows.push(new Row(this.frameWidth, this.settings));
+          rows.push(new Row(_this.frameWidth, _this.settings));
           return i++;
         }
-      }, this));
+      });
       return rows;
-    },
-    firefoxScrollbarBug: function(el) {
-      if (!$.browser.mozilla) {
-        return;
-      }
-      return setTimeout((function() {
-        var $lastLi, diff, i, index, randomRow, row, rows, _i, _len, _ref, _results;
-        rows = $(el).data('fillwidth.rows');
-        if (rows == null) {
-          return;
-        }
-        _ref = rows.slice(0, (rows.length - 2 + 1) || 9e9);
-        _results = [];
-        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-          row = _ref[_i];
-          $lastLi = row.lis[row.lis.length - 1].$el;
-          diff = $(el).width() - ($lastLi.outerWidth(true) + $lastLi.position().left);
-          _results.push((function() {
-            if (diff === 24) {
-              for (i = 1; i <= 15; i++) {
-                index = Math.round(Math.random() * (row.lis.length - 1));
-                randomRow = row.lis[index];
-                randomRow.incWidth();
-              }
-              return row.updateDOM();
-            }
-          })());
-        }
-        return _results;
-      }), 1);
     }
   };
+
   $.fn.fillwidth = function(method) {
     if (methods[method] != null) {
       return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
@@ -483,4 +498,5 @@
       return $.error("Method " + method + " does not exist on jQuery.fillwidth");
     }
   };
+
 }).call(this);

--- a/test/src/jquery.fillwidth.js
+++ b/test/src/jquery.fillwidth.js
@@ -275,19 +275,21 @@
         methods.initStyling.call(this, el);
         initFillWidth = __bind(function() {
           methods.fillWidth.call(this, el);
-          $(window).bind('resize.fillwidth', debounce((__bind(function() {
-            var fn, _i, _len;
-            callQueue.push((__bind(function() {
-              return methods.fillWidth.call(this, el);
-            }, this)));
-            if (callQueue.length === totalPlugins) {
-              for (_i = 0, _len = callQueue.length; _i < _len; _i++) {
-                fn = callQueue[_i];
-                fn();
+          if (!(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPod/i))) {
+            $(window).bind('resize.fillwidth', debounce((__bind(function() {
+              var fn, _i, _len;
+              callQueue.push((__bind(function() {
+                return methods.fillWidth.call(this, el);
+              }, this)));
+              if (callQueue.length === totalPlugins) {
+                for (_i = 0, _len = callQueue.length; _i < _len; _i++) {
+                  fn = callQueue[_i];
+                  fn();
+                }
+                return callQueue = [];
               }
-              return callQueue = [];
-            }
-          }, this)), 300));
+            }, this)), 300));
+          }
           return totalPlugins++;
         }, this);
         $imgs = $(el).find('img');
@@ -386,7 +388,6 @@
         row.lockHeight();
         row.updateDOM();
       }
-      methods.firefoxScrollbarBug.call(this, el);
       $(el).trigger('fillwidth.afterFillWidth');
       if (this.settings.afterFillWidth != null) {
         return this.settings.afterFillWidth();
@@ -440,36 +441,6 @@
         }
       }, this));
       return rows;
-    },
-    firefoxScrollbarBug: function(el) {
-      if (!$.browser.mozilla) {
-        return;
-      }
-      return setTimeout((function() {
-        var $lastLi, diff, i, index, randomRow, row, rows, _i, _len, _ref, _results;
-        rows = $(el).data('fillwidth.rows');
-        if (rows == null) {
-          return;
-        }
-        _ref = rows.slice(0, (rows.length - 2 + 1) || 9e9);
-        _results = [];
-        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-          row = _ref[_i];
-          $lastLi = row.lis[row.lis.length - 1].$el;
-          diff = $(el).width() - ($lastLi.outerWidth(true) + $lastLi.position().left);
-          _results.push((function() {
-            if (diff === 24) {
-              for (i = 1; i <= 15; i++) {
-                index = Math.round(Math.random() * (row.lis.length - 1));
-                randomRow = row.lis[index];
-                randomRow.incWidth();
-              }
-              return row.updateDOM();
-            }
-          })());
-        }
-        return _results;
-      }), 1);
     }
   };
   $.fn.fillwidth = function(method) {


### PR DESCRIPTION
This removes the Firefox 'ghost scrollbar fix'. In current versions of Firefox this was throwing errors and is unnecessary -- as the fix was for Firefox 3.6. 

Also adds a very basic gitignore
